### PR TITLE
Remove call to Wire.begin() which doesn't build

### DIFF
--- a/BMP280.cpp
+++ b/BMP280.cpp
@@ -25,15 +25,10 @@ BMP280::BMP280()
 {
 	//do nothing
 }
+
 /*
 *	Initialize library and coefficient for measurements
 */
-char BMP280::begin(int sdaPin, int sclPin)
-{
-	Wire.begin(sdaPin,sclPin);
-	return (readCalibration());
-}
-
 char BMP280::begin() 
 {
 	

--- a/BMP280.h
+++ b/BMP280.h
@@ -32,7 +32,6 @@ class BMP280
 		BMP280(); // base type
 
 		char begin();
-		char begin(int sdaPin, int sclPin);
 			// call pressure.begin() to initialize BMP280 before use
 			// returns 1 if success, 0 if failure (i2C connection problem.)
 				


### PR DESCRIPTION
This function causes build to fail at least on recent platformio (presumably recent arduino framework?) on atmega328 based Arduino board.